### PR TITLE
Use Debian instaead of Ubuntu as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM debian:jessie
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com>
 
 # Download latest package lists


### PR DESCRIPTION
This will reduce some of the bloat from Ubuntu, yet give us the apt-get goodness. From my initial tests the image size is smaller, and things seems to be functioning as expected.

Size of Ubuntu Image: `1.36gb`
Size of Debian Image: `673mb`
