### PR TITLE
Adds basic rsyslog listener and allows for multiple logstash configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -yq \
     openjdk-7-jre-headless \
-    wget
+    wget 
 
 # Download version 1.4.2 of logstash
 RUN cd /tmp && \
@@ -20,7 +20,7 @@ RUN /opt/logstash/bin/plugin install contrib
 
 # Copy build files to container root
 RUN mkdir /app
-ADD . /app
+COPY . /app
 
 # Elasticsearch HTTP
 EXPOSE 9200
@@ -30,6 +30,9 @@ EXPOSE 9300
 
 # Kibana
 EXPOSE 9292
+
+# rsyslog
+EXPOSE 514
 
 # Start logstash
 ENTRYPOINT ["/app/bin/boot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,5 @@ EXPOSE 9300
 # Kibana
 EXPOSE 9292
 
-# rsyslog
-EXPOSE 514
-
 # Start logstash
 ENTRYPOINT ["/app/bin/boot"]

--- a/bin/boot
+++ b/bin/boot
@@ -6,7 +6,10 @@ set -eo pipefail
 # Set LOGSTASH_TRACE to enable debugging
 [[ $LOGSTASH_TRACE ]] && set -x
 
-LOGSTASH_CONFIG_FILE="/opt/logstash.conf"
+mkdir -p /app/logstash-conf
+LOGSTASH_CONFIG_DIR="/app/logstash-conf"
+LOGSTASH_CONFIG_FILE="/app/logstash-conf/logstash.conf"
+
 
 # Download default conf if none present
 if [ ! -f $LOGSTASH_CONFIG_FILE ]; then
@@ -54,9 +57,12 @@ mkdir -p $SSL_CERT_PATH
 wget $LF_SSL_CERT_URL -O $LF_SSL_CERT_FILE
 wget $LF_SSL_CERT_KEY_URL -O $LF_SSL_CERT_KEY_FILE
 
+# Add custom logstash conf
+#cp /app/logstash-conf/* /opt/logstash/conf.d/
+
 # Fire up logstash!
 exec /opt/logstash/bin/logstash \
     agent \
-    --config $LOGSTASH_CONFIG_FILE \
+    --config $LOGSTASH_CONFIG_DIR \
     -- \
     web

--- a/logstash-conf/filter_rsyslog.conf
+++ b/logstash-conf/filter_rsyslog.conf
@@ -1,0 +1,8 @@
+filter {
+if [type] == "syslog" {
+syslog_pri { }
+date {
+match => [ "syslog_timestamp", "MMM d HH:mm:ss", "MMM dd HH:mm:ss" ]
+}
+}
+}

--- a/logstash-conf/filter_sshd_auth_failure.conf
+++ b/logstash-conf/filter_sshd_auth_failure.conf
@@ -1,0 +1,13 @@
+filter {
+if [program] == "sshd" and [message] =~ "Failed password" {
+
+grok {
+match => [ "message" , "Failed password for root from %{IP:remote_add$}" ]
+}
+
+geoip {
+source => "remote_addr"
+database => "/opt/logstash/vendor/geoip/GeoLiteCity.dat"
+}
+}
+}

--- a/logstash-conf/input_rsyslog.conf
+++ b/logstash-conf/input_rsyslog.conf
@@ -1,0 +1,6 @@
+input {
+syslog {
+type => syslog
+port => 514
+}
+}


### PR DESCRIPTION
Hi, great container!  Not sure if this PR interests you, but thought I would submit anyway.

We use a lot of syslog, and for demo purposes we need a way to send some live syslog traffic to the container.

This commit also adds a folder `logstash-conf` which can contain multiple configs, which are parsed in lexicographical order.