### PR TITLE
Use official Java image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7
+FROM java:7-jre
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com>
 
 # Download version 1.4.2 of logstash


### PR DESCRIPTION
The official java image basically does the same as yor first RUN command, so if you use that as base, downloads will be faster (because most people already have the java image available locally) and it shortens the dockerfile.
