### PR TITLE
Disable scripting in embedded elastic search

### DIFF
--- a/bin/boot
+++ b/bin/boot
@@ -54,6 +54,13 @@ mkdir -p $SSL_CERT_PATH
 wget $LF_SSL_CERT_URL -O $LF_SSL_CERT_FILE
 wget $LF_SSL_CERT_KEY_URL -O $LF_SSL_CERT_KEY_FILE
 
+cat > elasticsearch.yml <<- EOS
+---
+
+script.disable_dynamic: true    
+
+EOS
+
 # Fire up logstash!
 exec /opt/logstash/bin/logstash \
     agent \


### PR DESCRIPTION
The version of elasticsearch that comes with logstash 1.4.2 has quite a serious vulnerability, this patch helps prevent the remote code execution (I think). There might be a better way to do it, but I'll leave that to you :)

See http://bouk.co/blog/elasticsearch-rce/ for lots of info.

