### PR TITLE
If not using internal Elastic Search, you shouldn't expose it's port out...

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ If you want to link to container running Elasticsearch rather than use the embed
       -e LOGSTASH_CONFIG_URL=<your_logstash_config_url> \
       --link <your_es_container_name>:es \
       -p 9292:9292 \
-      -p 9200:9200 \
       pblittle/docker-logstash
 
 To have the linked Elasticsearch container's `bind_host` and `port` automatically detected, you will need to create an `ES_HOST` and `ES_PORT` placeholder in the `elasticsearch` definition in your logstash config file. For example:
@@ -56,7 +55,6 @@ If you are using an external Elasticsearch server rather than the embedded serve
     $ docker run -d \
       -e LOGSTASH_CONFIG_URL=<your_logstash_config_url> \
       -p 9292:9292 \
-      -p 9200:9200 \
       pblittle/docker-logstash
 
 ### Finally, verify the installation


### PR DESCRIPTION
Was just making me confused