### PR TITLE
Feature/Use custom patterns url

### DIFF
--- a/1.4/base/bin/boot
+++ b/1.4/base/bin/boot
@@ -16,6 +16,9 @@ LOGSTASH_CONFIG_URL=${LOGSTASH_CONFIG_URL:-${LOGSTASH_DEFAULT_CONFIG_URL}}
 
 LOGSTASH_SRC_DIR='/opt/logstash'
 
+LOGSTASH_PATTERNS_URL=${LOGSTASH_PATTERNS_URL:-''}
+LOGSTASH_PATTERNS_DIR="${LOGSTASH_SRC_DIR}/patterns"
+
 LOGSTASH_CONFIG_DIR="${LOGSTASH_SRC_DIR}/conf.d"
 LOGSTASH_CONFIG_FILE="${LOGSTASH_CONFIG_DIR}/logstash.conf"
 
@@ -49,6 +52,17 @@ function logstash_download_config() {
 
     if [ ! "$(ls -A $config_dir)" ]; then
         wget "$config_url" -O "$config_file"
+    fi
+}
+
+# Download a patterns file if user defined ENV
+#
+function logstash_download_pattern() {
+    local pattern_file="$LOGSTASH_PATTERNS_DIR/custom"
+    local pattern_url="$LOGSTASH_PATTERNS_URL"
+
+    if [ ! -z $pattern_url ]; then
+        wget "$pattern_url" -O "$pattern_file"
     fi
 }
 

--- a/1.4/base/bin/boot
+++ b/1.4/base/bin/boot
@@ -124,6 +124,8 @@ function main() {
 
     logstash_download_config
 
+    logstash_download_pattern
+
     logstash_sanitize_config
 
     kibana_sanitize_config


### PR DESCRIPTION
I recall reading somewhere that the future goal of this container is to download a tar/zip file of configuration but wasn't sure if that was going to include custom patterns or how far down the track that change will be.

For the time being I have added the mechanism to pull in a custom pattern file which get stored in `/opt/logstash/patterns/custom` similar to how the logstash.conf is pulled on container run.

