### PR TITLE
handle arguments passed in on run to alter logstash run command/services started

### DIFF
--- a/1.4/base/bin/boot
+++ b/1.4/base/bin/boot
@@ -81,12 +81,43 @@ function logstash_start_agent() {
     local config_dir="$LOGSTASH_CONFIG_DIR"
     local log_file="$LOGSTASH_LOG_FILE"
 
-    exec "$LOGSTASH_BINARY" \
-         agent \
-         --config "$config_dir" \
-         --log "$log_file" \
-         -- \
-         web
+    case "$1" in
+    # run just the agent
+    'agent') 
+        exec "$LOGSTASH_BINARY" \
+             agent \
+             --config "$config_dir" \
+             --log "$log_file" \
+             -- 
+        ;;
+    # test the logstash configuration
+    'configtest') 
+        exec "$LOGSTASH_BINARY" \
+             agent \
+             --config "$config_dir" \
+             --log "$log_file" \
+             --configtest \
+             -- 
+        ;;
+    # run just the web
+    'web') 
+        exec "$LOGSTASH_BINARY" \
+             web
+        ;;
+    # run agent+web (default operation)
+    *)
+        exec "$LOGSTASH_BINARY" \
+             agent \
+             --config "$config_dir" \
+             --log "$log_file" \
+             -- \
+             web
+        ;;
+    esac
+
+    echo "executing $CMD"
+        
+    exec "$LOGSTASH_BINARY $CMD"
 }
 
 function main() {
@@ -111,7 +142,7 @@ function main() {
 
     # Fire up logstash!
     #
-    logstash_start_agent
+    logstash_start_agent $@
 }
 
 main "$@"


### PR DESCRIPTION
Allow users to specify which services they want to run on `docker run`, eg:
```
docker run --rm -ti --name log -p 9292:9292 pblittle/docker-logstash web
```
to only enable the kibana web interface.
***

I have been running a similar version to this diff for a couple of weeks now so I could use this container to check my Logstash configuration (using the `agent --configtest` parameters) as part of our internal CI process.  After reading #57 it is clear that others would benefit from this functionality so I have expanded it to include other levels of Logstash operation (from looking at [the command-line flags](http://logstash.net/docs/1.4.2/flags)).

I've kept it quite verbose rather than building up a $CMD variable and executing it at the end as to keep it simple and easy to read if additional functionality needs to be added in the future.

At the moment it supports 4 modes of operation:
1. `agent` - only run the Logstash agent
2. `configtest` - run the agent with --configtest
3. `web` - only run the Kibana web interface
4. `default, nothing, anything else.` - run both the agent and web

I have kept the behaviour of no command the same as it is now to reduce impact when people upgrade.

