### PR TITLE
Hotfix/0.13.1

### DIFF
--- a/1.4/Makefile
+++ b/1.4/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash
-VERSION = 0.13.0
+VERSION = 0.13.1-dev
 
 # Set the LOGSTASH_CONFIG_URL env var to your logstash.conf file.
 # We will use our basic config if the value is empty.

--- a/1.4/Makefile
+++ b/1.4/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash
-VERSION = 0.13.1-dev
+VERSION = 0.13.1
 
 # Set the LOGSTASH_CONFIG_URL env var to your logstash.conf file.
 # We will use our basic config if the value is empty.

--- a/1.4/base/kibana.sh
+++ b/1.4/base/kibana.sh
@@ -8,6 +8,8 @@ set -e -o pipefail
 
 KIBANA_CONFIG_FILE="${LOGSTASH_SRC_DIR}/vendor/kibana/config.js"
 
+readonly PROXY_PROTOCOL_REGEX='\(http[s]\?\)'
+
 function es_proxy_host() {
     local host=${ES_PROXY_HOST:-'"+window.location.hostname+"'}
 
@@ -31,7 +33,7 @@ function kibana_sanitize_config() {
     local port="$(es_proxy_port)"
     local protocol="$(es_proxy_protocol)"
 
-    sed -e "s|http|${protocol}|g" \
+    sed -e "s|${PROXY_PROTOCOL_REGEX}|${protocol}|gI" \
         -e "s|\"+window.location.hostname+\"|${host}|g" \
         -e "s|9200|${port}|g" \
         -i "$KIBANA_CONFIG_FILE"

--- a/1.4/test/Makefile
+++ b/1.4/test/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash-test
-VERSION = 0.13.0
+VERSION = 0.13.1-dev
 
 BUILD_SRC = ${CURDIR}/../base
 

--- a/1.4/test/Makefile
+++ b/1.4/test/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash-test
-VERSION = 0.13.1-dev
+VERSION = 0.13.1
 
 BUILD_SRC = ${CURDIR}/../base
 

--- a/1.4/test/Makefile
+++ b/1.4/test/Makefile
@@ -30,6 +30,15 @@ test-elasticsearch-linked: build
 	fig build && \
 	fig up
 
+.PHONY: test-kibana-embedded
+test-kibana-embedded: build
+
+	cd ${CURDIR}/kibana-embedded && \
+	fig stop && \
+	fig rm && \
+	fig build && \
+	fig up
+
 .PHONY: test-logstash-configtest
 test-logstash-configtest: build
 

--- a/1.4/test/elasticsearch-embedded/Dockerfile
+++ b/1.4/test/elasticsearch-embedded/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.0
+FROM pblittle/docker-logstash:0.13.1-dev
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/elasticsearch-embedded/Dockerfile
+++ b/1.4/test/elasticsearch-embedded/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.1-dev
+FROM pblittle/docker-logstash:0.13.1
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/elasticsearch-linked/Dockerfile
+++ b/1.4/test/elasticsearch-linked/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.0
+FROM pblittle/docker-logstash:0.13.1-dev
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/elasticsearch-linked/Dockerfile
+++ b/1.4/test/elasticsearch-linked/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.1-dev
+FROM pblittle/docker-logstash:0.13.1
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/kibana-embedded/Dockerfile
+++ b/1.4/test/kibana-embedded/Dockerfile
@@ -1,0 +1,28 @@
+FROM pblittle/docker-logstash:0.13.1-dev
+MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
+
+# Download packages required to run the test suite
+#
+RUN apt-get update \
+    && apt-get install -yq \
+        apt-utils \
+        git \
+        net-tools \
+        --no-install-recommends \
+    && rm -rf /var/cache/apt/* \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and install BATS test framework
+#
+RUN git clone https://github.com/sstephenson/bats.git /tmp/bats \
+    && /tmp/bats/install.sh /usr/local \
+    && rm -rf /tmp/bats
+
+# $TERM needs to be set for bats
+#
+ENV TERM xterm-256color
+
+WORKDIR /app
+ADD test.bats /app/test.bats
+
+CMD [ '/usr/local/bin/bats', '/app/test.bats' ]

--- a/1.4/test/kibana-embedded/Dockerfile
+++ b/1.4/test/kibana-embedded/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.1-dev
+FROM pblittle/docker-logstash:0.13.1
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/kibana-embedded/docker-compose.yml
+++ b/1.4/test/kibana-embedded/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+logstash:
+  build: .
+  ports:
+   - '9200:9200'
+   - '9300:9300'
+   - '9292:9292'
+  environment:
+    ES_PROXY_PROTOCOL: https
+    LOGSTASH_TRACE: true

--- a/1.4/test/kibana-embedded/test.bats
+++ b/1.4/test/kibana-embedded/test.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+@test "Kibana's elasticsearch server is 'https://"+window.location.hostname+":9200'" {
+    run grep 'https://"+window.location.hostname+":9200' \
+        /opt/logstash/vendor/kibana/config.js
+
+    [ "$status" -eq 0 ]
+}

--- a/1.4/test/logstash-configtest/Dockerfile
+++ b/1.4/test/logstash-configtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.0
+FROM pblittle/docker-logstash:0.13.1-dev
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/logstash-configtest/Dockerfile
+++ b/1.4/test/logstash-configtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.13.1-dev
+FROM pblittle/docker-logstash:0.13.1
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite


### PR DESCRIPTION
This hotfix addresses the issue found in issue #72. The `sed` regex will now match an `http` or `https` proxy protocol.