### PR TITLE
do not download key+cert if already provided

### DIFF
--- a/1.4/base/logstash-forwarder.sh
+++ b/1.4/base/logstash-forwarder.sh
@@ -26,9 +26,13 @@ function forwarder_create_ssl_dir() {
 }
 
 function forwarder_download_cert() {
-    wget "$LF_SSL_CERT_URL" -O "$LF_SSL_CERT_FILE"
+    if [ ! -s "$LF_SSL_CERT_FILE" ]; then
+        wget "$LF_SSL_CERT_URL" -O "$LF_SSL_CERT_FILE"
+    fi
 }
 
 function forwarder_download_key() {
-    wget "$LF_SSL_CERT_KEY_URL" -O "$LF_SSL_CERT_KEY_FILE"
+    if [ ! -s "$LF_SSL_CERT_KEY_FILE" ]; then
+        wget "$LF_SSL_CERT_KEY_URL" -O "$LF_SSL_CERT_KEY_FILE"
+    fi
 }


### PR DESCRIPTION
This allows you to do `-v $(pwd)/ssl:/opt/ssl` and to either let the application download the key+cert and cache it, or provide key+cert yourself.
This also means one less dependency on public internet connection and less headache when trying to fix the proxy settings.