### PR TITLE
Corrects env variable names for external es service

### DIFF
--- a/1.4/Makefile
+++ b/1.4/Makefile
@@ -9,8 +9,8 @@ LOGSTASH_CONFIG_URL ?= https://gist.githubusercontent.com/pblittle/8778567/raw/l
 # Set the default Elasticsearch host and port. This will replace the ES_HOST
 # and ES_PORT values in your logstash config.
 #
-ES_SERVICE_HOST ?=
-ES_SERVICE_PORT ?= 9200
+ES_HOST ?=
+ES_PORT ?= 9200
 
 # Set the default Elasticsearch proxy host, port, and protocol. This will
 # replace the ES_PROXY_HOST, ES_PROXY_PORT, and ES_PROXY_PROTOCOL values in
@@ -28,7 +28,7 @@ LF_SSL_CERT_URL ?= https://gist.githubusercontent.com/pblittle/8994726/raw/insec
 
 define docker_run_flags
 -e LOGSTASH_CONFIG_URL=${LOGSTASH_CONFIG_URL} \
--e ES_SERVICE_HOST=${ES_SERVICE_HOST} \
+-e ES_HOST=${ES_HOST} \
 -e ES_PROXY_HOST=${ES_PROXY_HOST} \
 -e ES_PROXY_PROTOCOL=${ES_PROXY_PROTOCOL} \
 -e LF_SSL_CERT_URL=${LF_SSL_CERT_URL} \
@@ -42,9 +42,9 @@ ifdef ES_CONTAINER
 	docker_run_flags += --link $(ES_CONTAINER):es
 endif
 
-ifdef ES_SERVICE_PORT
-	docker_run_flags += -e $(ES_SERVICE_PORT)=$(ES_SERVICE_PORT)
-	docker_run_flags += -p $(ES_SERVICE_PORT):$(ES_SERVICE_PORT)
+ifdef ES_PORT
+	docker_run_flags += -e $(ES_PORT)=$(ES_PORT)
+	docker_run_flags += -p $(ES_PORT):$(ES_PORT)
 endif
 
 ifdef ES_PROXY_PORT


### PR DESCRIPTION
Current master branch allows no way to run an external ES service through setting of environment variables in docker run command. 

There is a mismatch in the names. Makefile uses "ES_SERVICE_HOST/PORT" while the rest of the code base is expecting / using "ES_HOST/PORT". Additionally, the README reflects the "ES_HOST/PORT" naming.