### PR TITLE
Fix External ElasticSearch Environment Variables

### DIFF
--- a/1.4/Makefile
+++ b/1.4/Makefile
@@ -9,8 +9,8 @@ LOGSTASH_CONFIG_URL ?= https://gist.githubusercontent.com/pblittle/8778567/raw/l
 # Set the default Elasticsearch host and port. This will replace the ES_HOST
 # and ES_PORT values in your logstash config.
 #
-ES_SERVICE_HOST ?=
-ES_SERVICE_PORT ?= 9200
+ES_HOST ?= 
+ES_PORT ?= 9200
 
 # Set the default Elasticsearch proxy host, port, and protocol. This will
 # replace the ES_PROXY_HOST, ES_PROXY_PORT, and ES_PROXY_PROTOCOL values in
@@ -28,7 +28,7 @@ LF_SSL_CERT_URL ?= https://gist.githubusercontent.com/pblittle/8994726/raw/insec
 
 define docker_run_flags
 -e LOGSTASH_CONFIG_URL=${LOGSTASH_CONFIG_URL} \
--e ES_SERVICE_HOST=${ES_SERVICE_HOST} \
+-e ES_HOST=${ES_HOST} \
 -e ES_PROXY_HOST=${ES_PROXY_HOST} \
 -e ES_PROXY_PROTOCOL=${ES_PROXY_PROTOCOL} \
 -e LF_SSL_CERT_URL=${LF_SSL_CERT_URL} \
@@ -42,11 +42,15 @@ ifdef ES_CONTAINER
 	docker_run_flags += --link $(ES_CONTAINER):es
 endif
 
-ifdef ES_SERVICE_PORT
-	docker_run_flags += -e $(ES_SERVICE_PORT)=$(ES_SERVICE_PORT)
-	docker_run_flags += -p $(ES_SERVICE_PORT):$(ES_SERVICE_PORT)
+# If ES_PORT is defined, make environment variable and expose port
+#
+ifdef ES_PORT
+	docker_run_flags += -e $(ES_PORT)=$(ES_PORT)
+	docker_run_flags += -p $(ES_PORT):$(ES_PORT)
 endif
 
+# If ES_PROXY_PORT is defined, make environment variable and expose port
+#
 ifdef ES_PROXY_PORT
 	docker_run_flags += -e $(ES_PROXY_PORT)=$(ES_PROXY_PORT)
 	docker_run_flags += -p $(ES_PROXY_PORT):$(ES_PROXY_PORT)

--- a/1.4/Makefile
+++ b/1.4/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash
-VERSION = 0.19.0
+VERSION = 0.20.0-SNAPSHOT
 
 # Set the LOGSTASH_CONFIG_URL env var to your logstash.conf file.
 # We will use our basic config if the value is empty.

--- a/1.4/test/Makefile
+++ b/1.4/test/Makefile
@@ -1,5 +1,5 @@
 NAME = pblittle/docker-logstash-test
-VERSION = 0.19.0
+VERSION = 0.20.0-SNAPSHOT
 
 BUILD_SRC = ${CURDIR}/../base
 

--- a/1.4/test/elasticsearch-embedded/Dockerfile
+++ b/1.4/test/elasticsearch-embedded/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.19.0
+FROM pblittle/docker-logstash:0.20.0-SNAPSHOT
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/elasticsearch-linked/Dockerfile
+++ b/1.4/test/elasticsearch-linked/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.19.0
+FROM pblittle/docker-logstash:0.20.0-SNAPSHOT
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/kibana-embedded/Dockerfile
+++ b/1.4/test/kibana-embedded/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.19.0
+FROM pblittle/docker-logstash:0.20.0-SNAPSHOT
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/1.4/test/logstash-configtest/Dockerfile
+++ b/1.4/test/logstash-configtest/Dockerfile
@@ -1,2 +1,2 @@
-FROM pblittle/docker-logstash:0.19.0
+FROM pblittle/docker-logstash:0.20.0-SNAPSHOT
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)

--- a/1.4/test/logstash-tarball-config/Dockerfile
+++ b/1.4/test/logstash-tarball-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM pblittle/docker-logstash:0.19.0
+FROM pblittle/docker-logstash:0.20.0-SNAPSHOT
 MAINTAINER P. Barrett Little <barrett@barrettlittle.com> (@pblittle)
 
 # Download packages required to run the test suite

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ If you are using an external Elasticsearch server, simply set the `ES_HOST` and 
     $ docker run -d \
       -e ES_HOST=<your_es_service_host> \
       -e ES_PORT=<your_es_service_port> \
+      -p <your_es_service_port>=<your_es_service_port> \
       -p 9292:9292 \
       pblittle/docker-logstash
 


### PR DESCRIPTION
To use an external ElasticSearch service, `elasticsearch.sh` looks for declared `ES_HOST` and `ES_PORT` variables or falls back on defaults if not defined. 

The Makefile declares these variables as `ES_SERVICE_PORT` and `ES_SERVICE_HOST`, so a `make` or `make run` will not set the variables that the `elasticsearch.sh` config helper is looking for. 

To demonstrate: set `ES_SERVICE_PORT` and `ES_SERVICE_HOST` in the Makefile, build and run, and then checkout the resulting `logstash.conf` file in the container. It will always show:
```
  elasticsearch {
    embedded => true
    host => "127.0.0.1"
    port => "9200"
    protocol => "http"
  }
```

This PR updates the Makefile to use `ES_HOST` and `ES_PORT` instead. 

Additionally, the README demonstrates the correct `docker run` command to run logstash with an external ES server by declaring the `ES_HOST` and `ES_PORT` variables, but doesn't open up the `ES_PORT` as well. 

This PR updates the README to expose `ES_PORT`. 